### PR TITLE
Remove auth from storage and database examples

### DIFF
--- a/example/realtime_database/index.dart
+++ b/example/realtime_database/index.dart
@@ -17,8 +17,6 @@ main() async {
       databaseURL: databaseUrl,
       storageBucket: storageBucket);
 
-  await app.auth().signInAnonymously();
-
   new MessagesApp().showMessages();
 }
 

--- a/example/storage/index.dart
+++ b/example/storage/index.dart
@@ -17,8 +17,6 @@ main() async {
       databaseURL: databaseUrl,
       storageBucket: storageBucket);
 
-  app.auth().signInAnonymously();
-
   new ImageUploadApp();
 }
 


### PR DESCRIPTION
Not needed if folks use the suggested test config – eliminates lots of
anonymous user accounts
